### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ClementTsang/Barista/security/code-scanning/2](https://github.com/ClementTsang/Barista/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/ci.yml` so this workflow does not rely on repository/organization defaults.

Best single fix (without changing existing functionality): define minimal read-only permissions at the workflow root, directly under `name` (or before `jobs`). For this workflow, a safe baseline is:

- `contents: read`

This applies to all jobs in the workflow, including the reusable workflow invocation job (`test-build`), unless overridden. It preserves existing triggers and job behavior while satisfying the requirement to explicitly constrain `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
