### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
         required: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/ClementTsang/Barista/security/code-scanning/4](https://github.com/ClementTsang/Barista/security/code-scanning/4)

Add an explicit `permissions` block to the workflow file `.github/workflows/build.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves existing functionality (`actions/checkout` can still read repository contents) and avoids granting implicit write privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
